### PR TITLE
Bump Swashbuckle.AspNetCore.SwaggerUI from 10.2.1 to 10.2.3

### DIFF
--- a/src/Api/packages.lock.json
+++ b/src/Api/packages.lock.json
@@ -172,9 +172,9 @@
       },
       "Swashbuckle.AspNetCore.SwaggerUI": {
         "type": "Direct",
-        "requested": "[10.2.1, )",
-        "resolved": "10.2.1",
-        "contentHash": "vzB8ZAGqXus3fdareJ9GHctaRP9ZL+wW9x8U7s1Y+BWprInFvSg6rpD9VhANNpwXA8fUHqu5Agjl/+hHG1BCQA=="
+        "requested": "[10.2.3, )",
+        "resolved": "10.2.3",
+        "contentHash": "nthWONRs/FJ4yyG206g1cC52WEG8EqrjuMWjGdR+5XG7lbjFto6NqcI9EMICgVFom/UivIjUVwI76ZHbHwTPfQ=="
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
   </ItemGroup>
   <ItemGroup Label="Transitives">
     <PackageVersion Include="Microsoft.OpenApi" Version="[2.7.6,3.0.0)" />

--- a/tests/ArchitectureTests/packages.lock.json
+++ b/tests/ArchitectureTests/packages.lock.json
@@ -639,8 +639,8 @@
       },
       "Swashbuckle.AspNetCore.SwaggerUI": {
         "type": "Transitive",
-        "resolved": "10.2.1",
-        "contentHash": "vzB8ZAGqXus3fdareJ9GHctaRP9ZL+wW9x8U7s1Y+BWprInFvSg6rpD9VhANNpwXA8fUHqu5Agjl/+hHG1BCQA=="
+        "resolved": "10.2.3",
+        "contentHash": "nthWONRs/FJ4yyG206g1cC52WEG8EqrjuMWjGdR+5XG7lbjFto6NqcI9EMICgVFom/UivIjUVwI76ZHbHwTPfQ=="
       },
       "System.ClientModel": {
         "type": "Transitive",
@@ -760,7 +760,7 @@
           "Serilog.Sinks.Async": "[2.1.0, )",
           "Serilog.Sinks.Console": "[6.1.1, )",
           "Services": "[1.0.0, )",
-          "Swashbuckle.AspNetCore.SwaggerUI": "[10.2.1, )"
+          "Swashbuckle.AspNetCore.SwaggerUI": "[10.2.3, )"
         }
       },
       "common": {

--- a/tests/E2ETests/packages.lock.json
+++ b/tests/E2ETests/packages.lock.json
@@ -783,8 +783,8 @@
       },
       "Swashbuckle.AspNetCore.SwaggerUI": {
         "type": "Transitive",
-        "resolved": "10.2.1",
-        "contentHash": "vzB8ZAGqXus3fdareJ9GHctaRP9ZL+wW9x8U7s1Y+BWprInFvSg6rpD9VhANNpwXA8fUHqu5Agjl/+hHG1BCQA=="
+        "resolved": "10.2.3",
+        "contentHash": "nthWONRs/FJ4yyG206g1cC52WEG8EqrjuMWjGdR+5XG7lbjFto6NqcI9EMICgVFom/UivIjUVwI76ZHbHwTPfQ=="
       },
       "System.ClientModel": {
         "type": "Transitive",
@@ -901,7 +901,7 @@
           "Serilog.Sinks.Async": "[2.1.0, )",
           "Serilog.Sinks.Console": "[6.1.1, )",
           "Services": "[1.0.0, )",
-          "Swashbuckle.AspNetCore.SwaggerUI": "[10.2.1, )"
+          "Swashbuckle.AspNetCore.SwaggerUI": "[10.2.3, )"
         }
       },
       "common": {

--- a/tests/IntegrationTests/packages.lock.json
+++ b/tests/IntegrationTests/packages.lock.json
@@ -923,8 +923,8 @@
       },
       "Swashbuckle.AspNetCore.SwaggerUI": {
         "type": "Transitive",
-        "resolved": "10.2.1",
-        "contentHash": "vzB8ZAGqXus3fdareJ9GHctaRP9ZL+wW9x8U7s1Y+BWprInFvSg6rpD9VhANNpwXA8fUHqu5Agjl/+hHG1BCQA=="
+        "resolved": "10.2.3",
+        "contentHash": "nthWONRs/FJ4yyG206g1cC52WEG8EqrjuMWjGdR+5XG7lbjFto6NqcI9EMICgVFom/UivIjUVwI76ZHbHwTPfQ=="
       },
       "System.ClientModel": {
         "type": "Transitive",
@@ -1049,7 +1049,7 @@
           "Serilog.Sinks.Async": "[2.1.0, )",
           "Serilog.Sinks.Console": "[6.1.1, )",
           "Services": "[1.0.0, )",
-          "Swashbuckle.AspNetCore.SwaggerUI": "[10.2.1, )"
+          "Swashbuckle.AspNetCore.SwaggerUI": "[10.2.3, )"
         }
       },
       "common": {


### PR DESCRIPTION
Updated [Swashbuckle.AspNetCore.SwaggerUI](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) from 10.2.1 to 10.2.3.

<details>
<summary>Release notes</summary>

_Sourced from [Swashbuckle.AspNetCore.SwaggerUI's releases](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/releases)._

## 10.2.3

## What's Changed

* Bump swagger-ui-dist to 5.32.7 by @​dependabot in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/4015

**Full Changelog**: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/compare/v10.2.2...v10.2.3

## 10.2.2

## What's Changed

* Update NuGet packages by @​martincostello in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3990
* Set `SOURCE_DATE_EPOCH` by @​martincostello in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3997
* Fix `InvalidOperationException` if no route matches by @​martincostello in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3999
* Fix empty parameter example not generated by @​dldl-cmd in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3932
* Map `[MinLength]`/`[MaxLength]` on dictionary properties to `minProperties`/`maxProperties` by @​KitKeen in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3922
* Fix conflicting required+nullable schema when only NonNullableReferen… by @​KitKeen in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3912
* Fix `ExposeSwaggerDocumentUrlsRoute` behaviour by @​martincostello in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/4000
* Use `NUGET_API_KEY` by @​martincostello in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/4006

## New Contributors

* @​KitKeen made their first contribution in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3922

**Full Changelog**: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/compare/v10.2.1...v10.2.2


Commits viewable in [compare view](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/compare/v10.2.1...v10.2.3).
</details>